### PR TITLE
Update CentOS version to 7

### DIFF
--- a/nailgun/nailgun/fixtures/openstack.yaml
+++ b/nailgun/nailgun/fixtures/openstack.yaml
@@ -1212,7 +1212,7 @@
 - pk: 1
   extend: *base_release
   fields:
-    name: "Juno on CentOS 6.5"
+    name: "Juno on CentOS 7.0"
     version: "2014.2.2-6.0.1"
     can_update_from_versions: []
     operating_system: "CentOS"


### PR DESCRIPTION
The base system we use is now CentOS 7.

Fixes: redmine #3159

Signed-off-by: huntxu mhuntxu@gmail.com
