### PR TITLE
remove node roles conflicts limit

### DIFF
--- a/nailgun/nailgun/fixtures/openstack.yaml
+++ b/nailgun/nailgun/fixtures/openstack.yaml
@@ -19,8 +19,6 @@
       controller:
         name: "Controller"
         description: "The controller initiates orchestration activities and provides an external API.  Other components like Glance (image storage), Keystone (identity management), Horizon (OpenStack dashboard) and Nova-Scheduler are installed on the controller as well."
-        conflicts:
-          - compute
         update_required:
           - compute
           - cinder
@@ -48,9 +46,6 @@
       mongo:
         name: "Telemetry - MongoDB"
         description: "A feature-complete and recommended database for storage of metering data from OpenStack Telemetry (Ceilometer)."
-        conflicts:
-          - compute
-          - ceph-osd
         restrictions:
           - condition: "cluster:status == 'operational'"
             message: "MongoDB node can not be added to an operational environment."


### PR DESCRIPTION
Allows assignment controller/mongo/compute/ceph-osd node role to the
same node.

Signed-off-by: blkart <blkart.org@gmail.com>