### PR TITLE
nailgun: fix npm installation of editorconfig 0.11.4.

### DIFF
--- a/nailgun/npm-shrinkwrap.json
+++ b/nailgun/npm-shrinkwrap.json
@@ -2188,7 +2188,7 @@
             },
             "editorconfig": {
               "version": "0.11.4",
-              "from": "editorconfig@^0.11.4",
+              "from": "git+https://github.com/editorconfig/editorconfig-core-js.git#v0.11.4",
               "dependencies": {
                 "commander": {
                   "version": "1.1.1",


### PR DESCRIPTION
editorconfig 0.11.4 from npm registry has wrong bin path in
package.json, use github url will fix this problem.

See https://github.com/npm/npm/issues/7992.

Signed-off-by: Zhao Chao <zhaochao1984@gmail.com>